### PR TITLE
Optimize memory usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.3.0",
         "psr/log": "^1.0",
         "solarium/solarium": "^3.0",
-        "webfactory/content-mapping": "^3.0"
+        "webfactory/content-mapping": "^3.2"
     },
 
     "autoload": {


### PR DESCRIPTION
By creating new Documents for updates, we get the possiblity of GC'ing them after
flushing the changes out to Solr. If the Documents taken from the result set
were updated, we could not simply discard them.

This bumps requirements for webfactory/content-mapping.
